### PR TITLE
Check if a style exists first before returning the category name

### DIFF
--- a/brewerydb/beer.py
+++ b/brewerydb/beer.py
@@ -52,7 +52,11 @@ class Beer(object):
     def style(self):
         """ Returns the name of the style
         category that this beer belongs to."""
-        return self.data['style']['category']['name']
+        style = self.data.get('style', None)
+        if style:
+            return style['category']['name']
+        else:
+            return None
     
     @property
     def label_image_large(self):


### PR DESCRIPTION
If the beer doesn't have a style associated with it, trying to get the style returns a key doesn't exist exception.  This checks first if there's a style and returns None if there isn't one.